### PR TITLE
Fix Typo on READMEs for kubectl

### DIFF
--- a/kops-kubenet-demo/Appendix/README.md
+++ b/kops-kubenet-demo/Appendix/README.md
@@ -166,7 +166,7 @@ $ kops update net410-kops-cluster.k8s.local --yes
 
 - Use following commands to validate cluster creation:
 ```
-$ kubeclt cluster-info
+$ kubectl cluster-info
 $ kops get cluster
 $ kops validate cluster
 ```

--- a/kops-kubenet-demo/README.md
+++ b/kops-kubenet-demo/README.md
@@ -72,7 +72,7 @@ Resolving deltas: 100% (52/52), done.
 
 - Display cluster information:
 ```
-kubeclt cluster-info
+kubectl cluster-info
 ```
 ```
 [ec2-user@ip-172-31-25-39 ~]$ kubectl cluster-info
@@ -797,6 +797,3 @@ kops delete cluster net410-kops-cluster.k8s.local --yes
   - Public-Private topology uses multiple route tables, kubenet uses only one route table
 - Other more advanced features, such as BGP, egress control, and mesh networking, are only available with different CNI providers.
 - When it comes to network providers, their are different options. One should choose option that meets their requirements
-
-
-


### PR DESCRIPTION
Noticed a couple of trivial typos on READMEs as I'm going through the workshop.